### PR TITLE
added custom-named vendors implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,34 @@ nodeAmf.getCounter('simple-counter').increment(10);
 nodeAmf.getGauge('simple-gauge').set(10)
 ```
 
+#### Setup vendors with custom names
+
+```typescript
+import {
+  Counter,
+  Gauge,
+  DogStatsd,
+  NodeAmf,
+  Prometheus,
+  SupportedVendorsEnum
+} from '@wojbach/nodeamf';
+
+const nodeAmf = NodeAmf.init({
+  vendors: [
+    new Prometheus({ name: 'vendor1' }),
+    new DogStatsd({ name: 'vendor2' }),
+    new Prometheus({ name: 'vendor3' }),
+  ],
+  metrics: [
+    new Counter('simple-counter', {}, ['vendor1', 'vendor2']),
+    new Gauge('simple-gauge', {}, ['vendor2', 'vendor3']),
+  ]
+});
+
+nodeAmf.getCounter('simple-counter').increment(10);
+nodeAmf.getGauge('simple-gauge').set(10)
+```
+
 #### Using metrics tags
 ```typescript
 import {

--- a/examples/example-01-simple-setup/app.ts
+++ b/examples/example-01-simple-setup/app.ts
@@ -1,12 +1,17 @@
-import { Counter, NodeAmf, Prometheus, SupportedVendorsEnum } from '@wojbach/nodeamf';
+import {
+  Counter,
+  NodeAmf,
+  Prometheus,
+  SupportedVendorsEnum,
+} from '@wojbach/nodeamf';
 
 const nodeAmf = NodeAmf.init({
-  vendors: [
-    new Prometheus()
-  ],
+  vendors: [new Prometheus()],
   metrics: [
-    new Counter('simple-counter', {}, [SupportedVendorsEnum.Prometheus])
-  ]
+    new Counter('simple-counter', {}, [SupportedVendorsEnum.Prometheus]),
+  ],
 });
 
 nodeAmf.getMetric<Counter>('simple-counter').increment(10);
+//or
+nodeAmf.getCounter('simple-counter').increment(10);

--- a/examples/example-07-custom-named-vendors-setup/app.ts
+++ b/examples/example-07-custom-named-vendors-setup/app.ts
@@ -1,0 +1,34 @@
+import {
+  Counter,
+  NodeAmf,
+  Prometheus,
+  SupportedVendorsEnum,
+} from '@wojbach/nodeamf';
+
+const nodeAmf = NodeAmf.init({
+  vendors: [
+    new Prometheus({ name: 'analytics' }),
+    new Prometheus({ name: 'finance' }),
+    new Prometheus(),
+  ],
+  metrics: [
+    new Counter('visits-counter', {}, [
+      'analytics',
+      SupportedVendorsEnum.Prometheus,
+    ]),
+    new Counter('purchase-counter', {}, ['finance']),
+    new Counter('http-calls', {}, [SupportedVendorsEnum.Prometheus]),
+  ],
+});
+
+nodeAmf.getMetric<Counter>('visits-counter').increment();
+//or
+nodeAmf.getCounter('visits-counter').increment();
+
+nodeAmf.getMetric<Counter>('purchase-counter').increment();
+//or
+nodeAmf.getCounter('purchase-counter').increment();
+
+nodeAmf.getMetric<Counter>('http-calls').increment();
+//or
+nodeAmf.getCounter('http-calls').increment();

--- a/src/lib/metrics/implementations/counter.spec.ts
+++ b/src/lib/metrics/implementations/counter.spec.ts
@@ -14,11 +14,15 @@ test('object properly initiates and class constructor arguments are accessible u
   t.notThrows(() => {
     counter = new Counter('counter1', { tags: ['tag1', 'tag2'] }, [
       SupportedVendorsEnum.Prometheus,
+      'another-named-vendor-client',
     ]);
   });
   t.is(counter.getName(), 'counter1');
   t.deepEqual(counter.getOptions(), { tags: ['tag1', 'tag2'] });
-  t.deepEqual(counter.getVendorsRegistry(), [SupportedVendorsEnum.Prometheus]);
+  t.deepEqual(counter.getVendorsRegistry(), [
+    SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
+  ]);
 });
 
 test('object properly returns its type', (t) => {
@@ -29,10 +33,12 @@ test('object properly returns its type', (t) => {
 test('measure method is callable mock, no state is saved', (t) => {
   const counter1 = new Counter('counter1', { tags: ['tag1', 'tag2'] }, [
     SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
   ]);
 
   const counter2 = new Counter('counter1', { tags: ['tag1', 'tag2'] }, [
     SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
   ]);
 
   t.notThrows(() => {

--- a/src/lib/metrics/implementations/event.spec.ts
+++ b/src/lib/metrics/implementations/event.spec.ts
@@ -14,11 +14,15 @@ test('object properly initiates and class constructor arguments are accessible u
   t.notThrows(() => {
     event = new Event('event1', { tags: ['tag1', 'tag2'] }, [
       SupportedVendorsEnum.Prometheus,
+      'another-named-vendor-client',
     ]);
   });
   t.is(event.getName(), 'event1');
   t.deepEqual(event.getOptions(), { tags: ['tag1', 'tag2'] });
-  t.deepEqual(event.getVendorsRegistry(), [SupportedVendorsEnum.Prometheus]);
+  t.deepEqual(event.getVendorsRegistry(), [
+    SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
+  ]);
 });
 
 test('object properly returns its type', (t) => {
@@ -29,10 +33,12 @@ test('object properly returns its type', (t) => {
 test('measure method is callable mock, no state is saved', (t) => {
   const event1 = new Event('event1', { tags: ['tag1', 'tag2'] }, [
     SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
   ]);
 
   const event2 = new Event('event1', { tags: ['tag1', 'tag2'] }, [
     SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
   ]);
 
   t.notThrows(() => {

--- a/src/lib/metrics/implementations/gauge.spec.ts
+++ b/src/lib/metrics/implementations/gauge.spec.ts
@@ -14,11 +14,15 @@ test('object properly initiates and class constructor arguments are accessible u
   t.notThrows(() => {
     gauge = new Gauge('gauge1', { tags: ['tag1', 'tag2'] }, [
       SupportedVendorsEnum.Prometheus,
+      'another-named-vendor-client',
     ]);
   });
   t.is(gauge.getName(), 'gauge1');
   t.deepEqual(gauge.getOptions(), { tags: ['tag1', 'tag2'] });
-  t.deepEqual(gauge.getVendorsRegistry(), [SupportedVendorsEnum.Prometheus]);
+  t.deepEqual(gauge.getVendorsRegistry(), [
+    SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
+  ]);
 });
 
 test('object properly returns its type', (t) => {
@@ -29,10 +33,12 @@ test('object properly returns its type', (t) => {
 test('measure method is callable mock, no state is saved', (t) => {
   const gauge1 = new Gauge('gauge1', { tags: ['tag1', 'tag2'] }, [
     SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
   ]);
 
   const gauge2 = new Gauge('gauge1', { tags: ['tag1', 'tag2'] }, [
     SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
   ]);
 
   t.notThrows(() => {

--- a/src/lib/metrics/implementations/histogram.spec.ts
+++ b/src/lib/metrics/implementations/histogram.spec.ts
@@ -15,7 +15,7 @@ test('object properly initiates and class constructor arguments are accessible u
     histogram = new Histogram(
       'histogram1',
       { tags: ['tag1', 'tag2'], buckets: [0.1, 5, 15, 50, 100, 500] },
-      [SupportedVendorsEnum.Prometheus]
+      [SupportedVendorsEnum.Prometheus, 'another-named-vendor-client']
     );
   });
   t.is(histogram.getName(), 'histogram1');
@@ -25,6 +25,7 @@ test('object properly initiates and class constructor arguments are accessible u
   });
   t.deepEqual(histogram.getVendorsRegistry(), [
     SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
   ]);
 });
 
@@ -37,13 +38,13 @@ test('measure method is callable mock, no state is saved', (t) => {
   const histogram1 = new Histogram(
     'histogram1',
     { tags: ['tag1', 'tag2'], buckets: [0.1, 5, 15, 50, 100, 500] },
-    [SupportedVendorsEnum.Prometheus]
+    [SupportedVendorsEnum.Prometheus, 'another-named-vendor-client']
   );
 
   const histogram2 = new Histogram(
     'histogram1',
     { tags: ['tag1', 'tag2'], buckets: [0.1, 5, 15, 50, 100, 500] },
-    [SupportedVendorsEnum.Prometheus]
+    [SupportedVendorsEnum.Prometheus, 'another-named-vendor-client']
   );
 
   t.notThrows(() => {

--- a/src/lib/metrics/implementations/set.spec.ts
+++ b/src/lib/metrics/implementations/set.spec.ts
@@ -14,11 +14,15 @@ test('object properly initiates and class constructor arguments are accessible u
   t.notThrows(() => {
     set = new Set('set1', { tags: ['tag1', 'tag2'] }, [
       SupportedVendorsEnum.Prometheus,
+      'another-named-vendor-client',
     ]);
   });
   t.is(set.getName(), 'set1');
   t.deepEqual(set.getOptions(), { tags: ['tag1', 'tag2'] });
-  t.deepEqual(set.getVendorsRegistry(), [SupportedVendorsEnum.Prometheus]);
+  t.deepEqual(set.getVendorsRegistry(), [
+    SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
+  ]);
 });
 
 test('object properly returns its type', (t) => {
@@ -29,10 +33,12 @@ test('object properly returns its type', (t) => {
 test('measure method is callable mock, no state is saved', (t) => {
   const set1 = new Set('set1', { tags: ['tag1', 'tag2'] }, [
     SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
   ]);
 
   const set2 = new Set('set1', { tags: ['tag1', 'tag2'] }, [
     SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
   ]);
 
   t.notThrows(() => {

--- a/src/lib/metrics/implementations/summary.spec.ts
+++ b/src/lib/metrics/implementations/summary.spec.ts
@@ -15,7 +15,7 @@ test('object properly initiates and class constructor arguments are accessible u
     summary = new Summary(
       'summary1',
       { tags: ['tag1', 'tag2'], percentiles: [0.01, 0.1, 0.9, 0.99] },
-      [SupportedVendorsEnum.Prometheus]
+      [SupportedVendorsEnum.Prometheus, 'another-named-vendor-client']
     );
   });
   t.is(summary.getName(), 'summary1');
@@ -23,7 +23,10 @@ test('object properly initiates and class constructor arguments are accessible u
     tags: ['tag1', 'tag2'],
     percentiles: [0.01, 0.1, 0.9, 0.99],
   });
-  t.deepEqual(summary.getVendorsRegistry(), [SupportedVendorsEnum.Prometheus]);
+  t.deepEqual(summary.getVendorsRegistry(), [
+    SupportedVendorsEnum.Prometheus,
+    'another-named-vendor-client',
+  ]);
 });
 
 test('object properly returns its type', (t) => {
@@ -35,13 +38,13 @@ test('measure method is callable mock, no state is saved', (t) => {
   const summary1 = new Summary(
     'summary1',
     { tags: ['tag1', 'tag2'], percentiles: [0.01, 0.1, 0.9, 0.99] },
-    [SupportedVendorsEnum.Prometheus]
+    [SupportedVendorsEnum.Prometheus, 'another-named-vendor-client']
   );
 
   const summary2 = new Summary(
     'summary1',
     { tags: ['tag1', 'tag2'], percentiles: [0.01, 0.1, 0.9, 0.99] },
-    [SupportedVendorsEnum.Prometheus]
+    [SupportedVendorsEnum.Prometheus, 'another-named-vendor-client']
   );
 
   t.notThrows(() => {

--- a/src/lib/metrics/metric.abstract.ts
+++ b/src/lib/metrics/metric.abstract.ts
@@ -6,12 +6,12 @@ export abstract class MetricAbstract<T extends Record<string, unknown>> {
   protected readonly name: string;
   protected readonly type: MetricsTypesEnum;
   protected readonly options: T;
-  protected readonly registerInVendors: SupportedVendorsEnum[] = [];
+  protected readonly registerInVendors: (SupportedVendorsEnum | string)[] = [];
 
   constructor(
     name: string,
     options: T,
-    registerInVendors: SupportedVendorsEnum[]
+    registerInVendors: (SupportedVendorsEnum | string)[]
   ) {
     this.name = name;
     this.options = options;
@@ -30,7 +30,7 @@ export abstract class MetricAbstract<T extends Record<string, unknown>> {
     return this.type;
   }
 
-  getVendorsRegistry(): SupportedVendorsEnum[] {
+  getVendorsRegistry(): (SupportedVendorsEnum | string)[] {
     return this.registerInVendors;
   }
 }

--- a/src/lib/metrics/metric.interface.ts
+++ b/src/lib/metrics/metric.interface.ts
@@ -6,5 +6,5 @@ export interface MetricInterface {
   getType(): MetricsTypesEnum;
   getName(): string;
   getOptions(): Record<string, unknown>;
-  getVendorsRegistry(): SupportedVendorsEnum[];
+  getVendorsRegistry(): (SupportedVendorsEnum | string)[];
 }

--- a/src/lib/node-amf.ts
+++ b/src/lib/node-amf.ts
@@ -12,7 +12,7 @@ import { SupportedVendorsEnum } from './vendors/supported-vendors.enum';
 import { VendorInterface } from './vendors/vendor.interface';
 
 export class NodeAmf {
-  private vendorsRegistry: Map<SupportedVendorsEnum, VendorInterface> =
+  private vendorsRegistry: Map<SupportedVendorsEnum | string, VendorInterface> =
     new Map();
   private metricsRegistry: Map<string, MetricInterface> = new Map();
 

--- a/src/lib/vendors/implementations/dog-statsd.spec.ts
+++ b/src/lib/vendors/implementations/dog-statsd.spec.ts
@@ -23,7 +23,7 @@ test('underlying client is accessible through getter', (t) => {
   const vendor = new DogStatsd({
     mock: true,
   });
-  t.truthy(vendor.getClient());
+  t.truthy(vendor.getClient()['mock']);
 });
 
 test('properly returns its name and supported metrics', (t) => {
@@ -36,6 +36,25 @@ test('properly returns its name and supported metrics', (t) => {
   vendor
     .getSupportedMetrics()
     .forEach((value) => t.truthy(MetricsTypesEnum[value]));
+});
+
+test('properly sets a custom name for vendor', (t) => {
+  const vendor = new DogStatsd({
+    name: 'my datadog 1',
+  });
+  t.is(vendor.getName(), 'my datadog 1');
+});
+
+test('properly sets a custom name for vendor and a client config', (t) => {
+  const vendor = new DogStatsd({
+    name: 'my datadog 1',
+    mock: true,
+    globalTags: ['foo', 'bar'],
+  });
+
+  t.is(vendor.getName(), 'my datadog 1');
+  t.truthy(vendor.getClient()['mock']);
+  t.deepEqual(vendor.getClient()['globalTags'], ['foo', 'bar']);
 });
 
 test('properly registers metric of supported type', (t) => {

--- a/src/lib/vendors/implementations/dog-statsd.ts
+++ b/src/lib/vendors/implementations/dog-statsd.ts
@@ -2,12 +2,12 @@ import { ClientOptions, StatsD } from 'hot-shots';
 
 import { MetricsTypesEnum } from '../../metrics/metrics-types.enum';
 import { SupportedVendorsEnum } from '../supported-vendors.enum';
+import { VendorAbstract } from '../vendor.abstract';
 import { VendorInterface } from '../vendor.interface';
 
-type DogStatsdConfigOptions = ClientOptions;
+type DogStatsdConfigOptions = ClientOptions & { name?: string };
 
-export class DogStatsd implements VendorInterface {
-  private readonly name: SupportedVendorsEnum = SupportedVendorsEnum.DogStatsD;
+export class DogStatsd extends VendorAbstract implements VendorInterface {
   private readonly supportedMetrics: MetricsTypesEnum[] = [
     MetricsTypesEnum.Counter,
     MetricsTypesEnum.Gauge,
@@ -29,11 +29,17 @@ export class DogStatsd implements VendorInterface {
   > = new Map();
 
   constructor(config?: DogStatsdConfigOptions) {
-    this.client = new StatsD(config);
-  }
+    super();
 
-  getName(): SupportedVendorsEnum {
-    return this.name;
+    const name = config?.name;
+    if (name) {
+      this.name = name;
+      delete config.name;
+    } else {
+      this.name = SupportedVendorsEnum.DogStatsD;
+    }
+
+    this.client = new StatsD(config);
   }
 
   getSupportedMetrics(): MetricsTypesEnum[] {

--- a/src/lib/vendors/implementations/prometheus.spec.ts
+++ b/src/lib/vendors/implementations/prometheus.spec.ts
@@ -25,6 +25,13 @@ test('properly returns its name and supported metrics', (t) => {
     .forEach((value) => t.truthy(MetricsTypesEnum[value]));
 });
 
+test('properly sets a custom name for vendor', (t) => {
+  const vendor = new Prometheus({
+    name: 'my prometheus 1',
+  });
+  t.is(vendor.getName(), 'my prometheus 1');
+});
+
 test('properly registers metric of supported type', (t) => {
   const vendor = new Prometheus();
 

--- a/src/lib/vendors/implementations/prometheus.ts
+++ b/src/lib/vendors/implementations/prometheus.ts
@@ -8,10 +8,13 @@ import promClient, {
 
 import { MetricsTypesEnum } from '../../metrics/metrics-types.enum';
 import { SupportedVendorsEnum } from '../supported-vendors.enum';
+import { VendorAbstract } from '../vendor.abstract';
 import { VendorInterface } from '../vendor.interface';
 
-export class Prometheus implements VendorInterface {
-  private readonly name: SupportedVendorsEnum = SupportedVendorsEnum.Prometheus;
+type PrometheusConfigOptions = {
+  name?: string;
+};
+export class Prometheus extends VendorAbstract implements VendorInterface {
   private readonly supportedMetrics: MetricsTypesEnum[] = [
     MetricsTypesEnum.Counter,
     MetricsTypesEnum.Gauge,
@@ -26,13 +29,18 @@ export class Prometheus implements VendorInterface {
       .replace(/[^a-zA-Z0-9:_]+/g, `_`);
   private metricsRegistry: Map<string, Metric<string>> = new Map();
 
-  constructor() {
+  constructor(config?: PrometheusConfigOptions) {
+    super();
+
+    const name = config?.name;
+    if (name) {
+      this.name = name;
+    } else {
+      this.name = SupportedVendorsEnum.Prometheus;
+    }
+
     this.client = promClient;
     this.client.register.clear();
-  }
-
-  getName(): SupportedVendorsEnum {
-    return this.name;
   }
 
   getSupportedMetrics(): MetricsTypesEnum[] {

--- a/src/lib/vendors/vendor.abstract.ts
+++ b/src/lib/vendors/vendor.abstract.ts
@@ -1,0 +1,9 @@
+import { SupportedVendorsEnum } from './supported-vendors.enum';
+
+export abstract class VendorAbstract {
+  protected name: SupportedVendorsEnum | string;
+
+  getName(): string {
+    return this.name;
+  }
+}

--- a/src/lib/vendors/vendor.interface.ts
+++ b/src/lib/vendors/vendor.interface.ts
@@ -3,7 +3,7 @@ import { MetricsTypesEnum } from '../metrics/metrics-types.enum';
 import { SupportedVendorsEnum } from './supported-vendors.enum';
 
 export interface VendorInterface {
-  getName(): SupportedVendorsEnum;
+  getName(): SupportedVendorsEnum | string;
 
   getSupportedMetrics(): MetricsTypesEnum[];
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Adds the ability to give a vendor client a custom name.

- **What is the current behavior?**
Cannot add a custom name for a vendor - has also a side effect that you cannot use more than one integration per vendor.

- **What is the new behavior (if this is a feature change)?**
You can name integrations with each vendor. You can configure multiple integrations with the same vendor.
